### PR TITLE
Added missing double quote for the select element for sorting products

### DIFF
--- a/Resources/views/storefront/component/sorting.html.twig
+++ b/Resources/views/storefront/component/sorting.html.twig
@@ -1,7 +1,7 @@
 {% set config = { sorting: current } %}
 
 <div class="sorting" data-listing-sorting="true" data-listing-sorting-options='{{ config|json_encode }}'>
-    <select class="sorting custom-select" aria-label="{{ 'general.sortingLabel'|trans|striptags }}>
+    <select class="sorting custom-select" aria-label="{{ 'general.sortingLabel'|trans|striptags }}">
         {% for sorting in sortings %}
             {% set key = sorting.key %}
             <option value="{{ key }}"{% if key == current %} selected{% endif %}>{{ sorting.snippet|trans|sw_sanitize }}</option>


### PR DESCRIPTION
Added a missing double quote for aria label which was breaking the select element for sorting products on a category page.