### PR TITLE
Fix close method of pseudo modal

### DIFF
--- a/Resources/app/storefront/src/utility/modal-extension/pseudo-modal.util.js
+++ b/Resources/app/storefront/src/utility/modal-extension/pseudo-modal.util.js
@@ -41,6 +41,7 @@ export default class PseudoModalUtil {
         const modal = this.getModal();
 
         this._modalInstance = bootstrap.Modal.getInstance(modal);
+        this._modalInstance.hide();
     }
 
     /**


### PR DESCRIPTION
When removing the version flag, the actual hide-call wasn't implemented.